### PR TITLE
Add RiftSight overlay

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,13 @@
+<p align="center">
+  <br>
+  <img width="400" src="./assets/d4-awesome.png" alt="logo of vue-awesome repository">
+</p>
 
+# Awesome Diablo 4 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 > A curated list of awesome tools for Diablo 4 game
 
-
 ## Contents
-
 
 - [Official Links](#official-links)
 - [Builds and guides](#builds-and-guides)
@@ -21,9 +24,7 @@
 - [Youtube Channels](#youtube-channels)
 - [Contribute](#contribute)
 
-
 ## Official Links
-
 
 - [Official Website](https://diablo4.blizzard.com/pt-br/)
 - [Official Forum](https://us.forums.blizzard.com/en/d4/)
@@ -31,9 +32,7 @@
 - [Blizz Tracker](https://us.forums.blizzard.com/en/d4/g/blizzard-tracker/activity/posts?category_id=7)
 - [Patch Notes](https://news.blizzard.com/en-us/diablo4/23964909/diablo-iv-patch-notes)
 
-
 ## Builds and guides
-
 
 - [D4 Builds](https://d4builds.gg/) - Meta builds for all classes.
 - [Maxroll](https://maxroll.gg/d4/build-guides?) - Maxroll build guides
@@ -44,42 +43,34 @@
 - [Diablo4.life Builds](https://diablo4.life/builds/starter-builds) - Diablo4.life build guides
 - [Diablo4 Chronicles](https://diablo4.cc/us) - Diablo 4 Wiki
 
-
 ## Tools
-
 
 ### Profile and Leaderboard Trackers
 - [D4 Armory](https://d4armory.io/) - Unofficial leaderboard and character profile lookup tool
 - [Diablo 4 Armory Fetcher](https://github.com/ryancollingwood/diablo_4_armory_fetcher) - Fetch and store your character profiles using [D4 Armory](https://d4armory.io/) and Github Actions
-
 
 ### Build Planners
 - [D4 Build Planner](https://d4builds.gg/my-builds/) - D4 Build Planner
 - [Maxroll Item Planner](https://maxroll.gg/d4/planner) - Maxroll Item Planner
 - [Mobalytics Build Planner](https://app.mobalytics.gg/diablo-4/build-planner) - Mobalytics Build Planner
 
-
 ### Skill Trees
 - [Skill Trees](https://d4builds.gg/skill-trees/) - D4Build.gg Skill Trees
 - [Skill Calculator](https://maxroll.gg/d4/skill-calculator) - Maxroll Skill Calculator
 - [D4 Planner Skill Tree](https://d4planner.io/skilltree/Barbarian/) - D4 Planner Skill Tree
 
-
 ### Damage Calculators
 - [Damage Calculator](https://www.d4ut.net/) - D4UT Damage Calculator, helps to forecast your damage after all the multipliers
 - [Damage Calculator Spreadsheet](https://docs.google.com/spreadsheets/d/1jDhNqYytNyoSChNIMp5YIBIDUrxrOMPWVVANJQDTPBU/edit#gid=1662451896) - Damage Calculator Spreadsheet (pt-BR)
-
 
 ### Item Databases
 - [Gambling Aspect](https://diablo4.life/tools/gambling) - Diablo4.life Gambling Aspect helps to identify which item you should target at The Purveyor of Curiosities to get the best possible odds at getting the legendary aspect you are looking for.
 - [Unique Target Farming](https://diablo4.life/tools/target-farming) - Diablo4.life Unique Target Farming helps to identify which monster you should target to get the best possible odds at getting the legendary item you are looking for.
 - [Aspects Tracker](https://d4aspects.com/) -  Track all of your aspects in a single place.
 
-
 ### Event Trackers
 - [Event Tracker](https://diablo4.life/trackers/overview) - Diablo4.life Event Tracker helps to identify which event is currently active and when the next event will start.
 - [Helltides Event Tracker](https://helltides.com/) - Helltides Event Tracker helps to identify which event is currently active and when the next event will start.
-
 
 ### Interactive Maps
 - [Diablo 4 Map](https://diablo4.th.gl/) - Diablo 4 Map with custom routes
@@ -89,7 +80,6 @@
 - [Pure Diablo Interactive Map](https://diablo4.purediablo.com/map/) - Pure Diablo Interactive Map
 - [Diablo Fans Interactive Map](https://www.diablofans.com/zones/d4/1-sanctuary) - Diablo Fans Interactive Map
 
-
 ### Overlays
 - [Diablo 4 Map](https://www.overwolf.com/app/Leon_Machens-Diablo_4_Map) - Diablo 4 Map with player position and transparent overlay
 - [Diablo 4 Companion](https://github.com/josdemmers/Diablo4Companion) - Specify your prefered affixes for each gear slot and monitor them in game
@@ -97,15 +87,12 @@
 - [Diablo Dungeon Timer](https://github.com/Shaydera/DiabloDungeonTimer) - Software which automatically tracks and times all dungeons entered in Diablo IV
 - [RiftSight](https://d4builds.ai/en/tools/) - Diablo IV game overlay with live Helltide tracking and interactive zone maps.
 
-
 ## Tier Lists
 - [Nightmare Dungeon Tier List](https://docs.google.com/spreadsheets/u/1/d/143tXzN_7-yoQCy7QEjo924UT2kWqH1VhWyXEsOvlwgA/htmlview?usp=sharing) - @wudijo Nightmare Dungeon Tier List
-
 
 ## Trading
 - [Diablo 4 Marketplace](https://diablotrade.gg/) - Site to browse and post listings for items, turns screenshots into listings
 - [Sanctuary - Diablo 4 Community Discord](https://discord.gg/diablo4#discord) - Sections for softcore and hardcore trading
-
 
 ## Youtube Channels
 - [Wudijo](https://www.youtube.com/@wudijo) - Wudijo Youtube Channel
@@ -117,3 +104,13 @@
 - [Raxxanterax](https://www.youtube.com/@Raxxanterax) - Raxxanterax Youtube Channel
 - [Kripparrian](https://www.youtube.com/@Kripparrian) - Kripparrian Youtube Channel
 - [echohack](https://www.youtube.com/@echohack) - echohack Youtube Channel
+- [vigiabr](https://www.youtube.com/@vigiabr) - Jogatinas Saudáveis Youtube Channel
+
+## Contribute
+
+Contributions welcome! Read the [contribution guidelines](contributing.md) first, you can open a PR to add your link or 
+send me an email at contato@carlosgartner.com.br
+
+## Ad spaces
+
+You can buy an ad space to promote your product or service on this list. Send me an email at contato@carlosgartner.com.br

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,10 @@
-<p align="center">
-  <br>
-  <img width="400" src="./assets/d4-awesome.png" alt="logo of vue-awesome repository">
-</p>
 
-# Awesome Diablo 4 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 > A curated list of awesome tools for Diablo 4 game
 
+
 ## Contents
+
 
 - [Official Links](#official-links)
 - [Builds and guides](#builds-and-guides)
@@ -24,7 +21,9 @@
 - [Youtube Channels](#youtube-channels)
 - [Contribute](#contribute)
 
+
 ## Official Links
+
 
 - [Official Website](https://diablo4.blizzard.com/pt-br/)
 - [Official Forum](https://us.forums.blizzard.com/en/d4/)
@@ -32,7 +31,9 @@
 - [Blizz Tracker](https://us.forums.blizzard.com/en/d4/g/blizzard-tracker/activity/posts?category_id=7)
 - [Patch Notes](https://news.blizzard.com/en-us/diablo4/23964909/diablo-iv-patch-notes)
 
+
 ## Builds and guides
+
 
 - [D4 Builds](https://d4builds.gg/) - Meta builds for all classes.
 - [Maxroll](https://maxroll.gg/d4/build-guides?) - Maxroll build guides
@@ -43,34 +44,42 @@
 - [Diablo4.life Builds](https://diablo4.life/builds/starter-builds) - Diablo4.life build guides
 - [Diablo4 Chronicles](https://diablo4.cc/us) - Diablo 4 Wiki
 
+
 ## Tools
+
 
 ### Profile and Leaderboard Trackers
 - [D4 Armory](https://d4armory.io/) - Unofficial leaderboard and character profile lookup tool
 - [Diablo 4 Armory Fetcher](https://github.com/ryancollingwood/diablo_4_armory_fetcher) - Fetch and store your character profiles using [D4 Armory](https://d4armory.io/) and Github Actions
+
 
 ### Build Planners
 - [D4 Build Planner](https://d4builds.gg/my-builds/) - D4 Build Planner
 - [Maxroll Item Planner](https://maxroll.gg/d4/planner) - Maxroll Item Planner
 - [Mobalytics Build Planner](https://app.mobalytics.gg/diablo-4/build-planner) - Mobalytics Build Planner
 
+
 ### Skill Trees
 - [Skill Trees](https://d4builds.gg/skill-trees/) - D4Build.gg Skill Trees
 - [Skill Calculator](https://maxroll.gg/d4/skill-calculator) - Maxroll Skill Calculator
 - [D4 Planner Skill Tree](https://d4planner.io/skilltree/Barbarian/) - D4 Planner Skill Tree
 
+
 ### Damage Calculators
 - [Damage Calculator](https://www.d4ut.net/) - D4UT Damage Calculator, helps to forecast your damage after all the multipliers
 - [Damage Calculator Spreadsheet](https://docs.google.com/spreadsheets/d/1jDhNqYytNyoSChNIMp5YIBIDUrxrOMPWVVANJQDTPBU/edit#gid=1662451896) - Damage Calculator Spreadsheet (pt-BR)
+
 
 ### Item Databases
 - [Gambling Aspect](https://diablo4.life/tools/gambling) - Diablo4.life Gambling Aspect helps to identify which item you should target at The Purveyor of Curiosities to get the best possible odds at getting the legendary aspect you are looking for.
 - [Unique Target Farming](https://diablo4.life/tools/target-farming) - Diablo4.life Unique Target Farming helps to identify which monster you should target to get the best possible odds at getting the legendary item you are looking for.
 - [Aspects Tracker](https://d4aspects.com/) -  Track all of your aspects in a single place.
 
+
 ### Event Trackers
 - [Event Tracker](https://diablo4.life/trackers/overview) - Diablo4.life Event Tracker helps to identify which event is currently active and when the next event will start.
 - [Helltides Event Tracker](https://helltides.com/) - Helltides Event Tracker helps to identify which event is currently active and when the next event will start.
+
 
 ### Interactive Maps
 - [Diablo 4 Map](https://diablo4.th.gl/) - Diablo 4 Map with custom routes
@@ -80,18 +89,23 @@
 - [Pure Diablo Interactive Map](https://diablo4.purediablo.com/map/) - Pure Diablo Interactive Map
 - [Diablo Fans Interactive Map](https://www.diablofans.com/zones/d4/1-sanctuary) - Diablo Fans Interactive Map
 
+
 ### Overlays
 - [Diablo 4 Map](https://www.overwolf.com/app/Leon_Machens-Diablo_4_Map) - Diablo 4 Map with player position and transparent overlay
 - [Diablo 4 Companion](https://github.com/josdemmers/Diablo4Companion) - Specify your prefered affixes for each gear slot and monitor them in game
 - [Diablo QoL](https://r.nf/r/diablo_qol) - Duplicate Aspect counter and filter dropdown for stash & inventory
 - [Diablo Dungeon Timer](https://github.com/Shaydera/DiabloDungeonTimer) - Software which automatically tracks and times all dungeons entered in Diablo IV
+- [RiftSight](https://d4builds.ai/en/tools/) - Diablo IV game overlay with live Helltide tracking and interactive zone maps.
+
 
 ## Tier Lists
 - [Nightmare Dungeon Tier List](https://docs.google.com/spreadsheets/u/1/d/143tXzN_7-yoQCy7QEjo924UT2kWqH1VhWyXEsOvlwgA/htmlview?usp=sharing) - @wudijo Nightmare Dungeon Tier List
 
+
 ## Trading
 - [Diablo 4 Marketplace](https://diablotrade.gg/) - Site to browse and post listings for items, turns screenshots into listings
 - [Sanctuary - Diablo 4 Community Discord](https://discord.gg/diablo4#discord) - Sections for softcore and hardcore trading
+
 
 ## Youtube Channels
 - [Wudijo](https://www.youtube.com/@wudijo) - Wudijo Youtube Channel
@@ -103,13 +117,3 @@
 - [Raxxanterax](https://www.youtube.com/@Raxxanterax) - Raxxanterax Youtube Channel
 - [Kripparrian](https://www.youtube.com/@Kripparrian) - Kripparrian Youtube Channel
 - [echohack](https://www.youtube.com/@echohack) - echohack Youtube Channel
-- [vigiabr](https://www.youtube.com/@vigiabr) - Jogatinas Saudáveis Youtube Channel
-
-## Contribute
-
-Contributions welcome! Read the [contribution guidelines](contributing.md) first, you can open a PR to add your link or 
-send me an email at contato@carlosgartner.com.br
-
-## Ad spaces
-
-You can buy an ad space to promote your product or service on this list. Send me an email at contato@carlosgartner.com.br


### PR DESCRIPTION
## Summary

Adds RiftSight to the Overlays section.

RiftSight is a Diablo IV game overlay with live Helltide tracking and interactive zone maps.

Link: https://d4builds.ai/en/tools/